### PR TITLE
next-js-example 보면서 구글 애널리틱스 다시연동

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,8 @@ import { Inter } from "next/font/google";
 import Header from "../components/Header";
 import Providers from "@/Providers";
 import Head from "next/head";
+import Script from "next/script";
+import * as gtag from "@libs/gtag";
 
 /** 
   Inter 는 구글 폰트에서 제공하는 폰트 중 하나입니다.
@@ -31,22 +33,24 @@ export default function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <Head>
         <script
-          async
-          src={`https://www.googletagmanager.com/gtag/js?id=${process.env.GA_TRACKING_ID}`}
-        />
-        <script
           dangerouslySetInnerHTML={{
             __html: `
-                window.dataLayer = window.dataLayer || [];
-                function gtag(){dataLayer.push(arguments);}
-                gtag('js', new Date());
-                gtag('config', '${process.env.GA_TRACKING_ID}', {
-                  page_path: window.location.pathname,
-                });
-              `,
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+              gtag('js', new Date());
+
+              gtag('config', '${gtag.GA_TRACKING_ID}', {
+                page_path: window.location.pathname,
+              });
+            `,
           }}
         />
       </Head>
+      {/* Global Site Tag (gtag.js) - Google Analytics */}
+      <Script
+        strategy="afterInteractive"
+        src={`https://www.googletagmanager.com/gtag/js?id=${gtag.GA_TRACKING_ID}`}
+      />
       <body className={inter.className} suppressHydrationWarning={true}>
         <Providers>
           <Header />

--- a/src/libs/gtag.ts
+++ b/src/libs/gtag.ts
@@ -1,0 +1,30 @@
+export const GA_TRACKING_ID = process.env.GA_TRACKING_ID;
+
+declare global {
+  interface Window {
+    gtag?: any;
+  }
+}
+
+interface eventParams {
+  action: string;
+  category: string;
+  label: string;
+  value: number;
+}
+
+// https://developers.google.com/analytics/devguides/collection/gtagjs/pages
+export const pageview = (url: string) => {
+  window.gtag("config", GA_TRACKING_ID, {
+    page_path: url,
+  });
+};
+
+// https://developers.google.com/analytics/devguides/collection/gtagjs/events
+export const event = ({ action, category, label, value }: eventParams) => {
+  window.gtag("event", action, {
+    event_category: category,
+    event_label: label,
+    value: value,
+  });
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,8 @@
       "@services/*": ["./src/app/server/services/*"],
       "@middleware/*": ["./src/app/server/middleware/*"],
       "@axios/*": ["./src/app/axios/*"],
-      "@graphql/*": ["./src/graphql/*"]
+      "@graphql/*": ["./src/graphql/*"],
+      "@libs/*": ["./src/libs/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
참조

https://github.com/vercel/next.js/blob/canary/examples/with-google-analytics/pages/contact.js